### PR TITLE
feat: FieldError와 ObjectError를 사용하여 사용자 입력값 유지

### DIFF
--- a/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV2.java
+++ b/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV2.java
@@ -47,7 +47,7 @@ public class ValidationItemControllerV2 {
         return "validation/v2/addForm";
     }
 
-    @PostMapping("/add")
+//    @PostMapping("/add")
     public String addItemV1(@ModelAttribute Item item, BindingResult bindingResult,  RedirectAttributes redirectAttributes, Model model) {
 
         //검증 오류 결과를 보관
@@ -84,6 +84,36 @@ public class ValidationItemControllerV2 {
             return "validation/v2/addForm";
         }
 
+        //성공 로직
+        Item savedItem = itemRepository.save(item);
+        redirectAttributes.addAttribute("itemId", savedItem.getId());
+        redirectAttributes.addAttribute("status", true);
+        return "redirect:/validation/v2/items/{itemId}";
+    }
+
+    @PostMapping("/add")
+    public String addItemV2(@ModelAttribute Item item, BindingResult bindingResult,
+                            RedirectAttributes redirectAttributes) {
+        if (!StringUtils.hasText(item.getItemName())) {
+            bindingResult.addError(new FieldError("item", "itemName",item.getItemName(), false, null, null, "상품 이름은 필수입니다."));
+        }
+        if (item.getPrice() == null || item.getPrice() < 1000 || item.getPrice() > 1000000) {
+            bindingResult.addError(new FieldError("item", "price", item.getPrice(), false, null, null, "가격은 1,000 ~ 1,000,000 까지 허용합니다."));
+        }
+        if (item.getQuantity() == null || item.getQuantity() >= 10000) {
+            bindingResult.addError(new FieldError("item", "quantity", item.getQuantity(), false, null, null, "수량은 최대 9,999 까지 허용합니다."));
+        }
+        //특정 필드 예외가 아닌 전체 예외
+        if (item.getPrice() != null && item.getQuantity() != null) {
+            int resultPrice = item.getPrice() * item.getQuantity();
+            if (resultPrice < 10000) {
+                bindingResult.addError(new ObjectError("item", null, null, "가격 * 수량의 합은 10,000원 이상이어야 합니다. 현재 값 = " + resultPrice));
+            }
+        }
+        if (bindingResult.hasErrors()) {
+            log.info("errors={}", bindingResult);
+            return "validation/v2/addForm";
+        }
         //성공 로직
         Item savedItem = itemRepository.save(item);
         redirectAttributes.addAttribute("itemId", savedItem.getId());


### PR DESCRIPTION
### 작업 내용
- FieldError, ObjectError 생성자에 사용자 입력값(rejectedValue) 포함
- 검증 실패 시 입력값이 사라지지 않고 화면에 유지되도록 처리
- BindingResult에 오류 메시지와 함께 거절된 값 보관
- 타임리프의 th:field가 FieldError의 값 우선 사용

### 기타 참고 사항
- bindingFailure는 바인딩 오류가 아닌 경우 false로 설정
- 타입 오류가 발생한 필드도 FieldError로 관리됨
