### PR TITLE
feat: 오류 메시지를 코드 기반으로 처리하도록 개선

### DIFF
--- a/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV2.java
+++ b/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV2.java
@@ -91,7 +91,7 @@ public class ValidationItemControllerV2 {
         return "redirect:/validation/v2/items/{itemId}";
     }
 
-    @PostMapping("/add")
+//    @PostMapping("/add")
     public String addItemV2(@ModelAttribute Item item, BindingResult bindingResult,
                             RedirectAttributes redirectAttributes) {
         if (!StringUtils.hasText(item.getItemName())) {
@@ -108,6 +108,36 @@ public class ValidationItemControllerV2 {
             int resultPrice = item.getPrice() * item.getQuantity();
             if (resultPrice < 10000) {
                 bindingResult.addError(new ObjectError("item", null, null, "가격 * 수량의 합은 10,000원 이상이어야 합니다. 현재 값 = " + resultPrice));
+            }
+        }
+        if (bindingResult.hasErrors()) {
+            log.info("errors={}", bindingResult);
+            return "validation/v2/addForm";
+        }
+        //성공 로직
+        Item savedItem = itemRepository.save(item);
+        redirectAttributes.addAttribute("itemId", savedItem.getId());
+        redirectAttributes.addAttribute("status", true);
+        return "redirect:/validation/v2/items/{itemId}";
+    }
+
+    @PostMapping("/add")
+    public String addItemV3(@ModelAttribute Item item, BindingResult bindingResult,
+                            RedirectAttributes redirectAttributes) {
+        if (!StringUtils.hasText(item.getItemName())) {
+            bindingResult.addError(new FieldError("item", "itemName",item.getItemName(), false, new String[]{"required.item.itemName"}, null, null));
+        }
+        if (item.getPrice() == null || item.getPrice() < 1000 || item.getPrice() > 1000000) {
+            bindingResult.addError(new FieldError("item", "price", item.getPrice(), false, new String[]{"range.item.price"}, new Object[]{1000, 1000000}, null));
+        }
+        if (item.getQuantity() == null || item.getQuantity() >= 10000) {
+            bindingResult.addError(new FieldError("item", "quantity", item.getQuantity(), false, new String[]{"max.item.quantity"}, new Object[]{9999}, null));
+        }
+        //특정 필드 예외가 아닌 전체 예외
+        if (item.getPrice() != null && item.getQuantity() != null) {
+            int resultPrice = item.getPrice() * item.getQuantity();
+            if (resultPrice < 10000) {
+                bindingResult.addError(new ObjectError("item", new String[]{"totalPriceMin"}, new Object[]{10000, resultPrice}, null));
             }
         }
         if (bindingResult.hasErrors()) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 #logging.level.org.apache.coyote.http11=debug
+spring.messages.basename=messages, errors

--- a/src/main/resources/errors.properties
+++ b/src/main/resources/errors.properties
@@ -1,0 +1,4 @@
+required.item.itemName=상품 이름은 필수입니다.
+range.item.price=가격은 {0} ~ {1} 까지 허용합니다.
+max.item.quantity=수량은 최대 {0} 까지 허용합니다.
+totalPriceMin=가격 * 수량의 합은 {0}원 이상이어야 합니다. 현재 값 = {1}


### PR DESCRIPTION
### 구현 내용
- ValidationItemControllerV2에 addItemV3() 메서드를 추가하여 오류 메시지를 코드 기반으로 처리
- FieldError, ObjectError에 메시지 코드 및 인자 값을 전달하여 국제화 및 유지보수 용이성 확보
- errors.properties 파일을 분리하여 오류 메시지 별도 관리
- application.properties에 spring.messages.basename 설정 추가

### 주요 변경 사항
- 오류 메시지 하드코딩 제거 → 코드 기반 메시지로 전환
- 검증 실패 시 FieldError, ObjectError에 메시지 코드 전달
