### PR TITLE
feat: rejectValue(), reject() 기반 메시지 처리 로직 추가

### DIFF
--- a/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV2.java
+++ b/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV2.java
@@ -121,9 +121,12 @@ public class ValidationItemControllerV2 {
         return "redirect:/validation/v2/items/{itemId}";
     }
 
-    @PostMapping("/add")
+//    @PostMapping("/add")
     public String addItemV3(@ModelAttribute Item item, BindingResult bindingResult,
                             RedirectAttributes redirectAttributes) {
+        log.info("objectName={} ", bindingResult.getObjectName());
+        log.info("target={} ", bindingResult.getTarget());
+
         if (!StringUtils.hasText(item.getItemName())) {
             bindingResult.addError(new FieldError("item", "itemName",item.getItemName(), false, new String[]{"required.item.itemName"}, null, null));
         }
@@ -138,6 +141,40 @@ public class ValidationItemControllerV2 {
             int resultPrice = item.getPrice() * item.getQuantity();
             if (resultPrice < 10000) {
                 bindingResult.addError(new ObjectError("item", new String[]{"totalPriceMin"}, new Object[]{10000, resultPrice}, null));
+            }
+        }
+        if (bindingResult.hasErrors()) {
+            log.info("errors={}", bindingResult);
+            return "validation/v2/addForm";
+        }
+        //성공 로직
+        Item savedItem = itemRepository.save(item);
+        redirectAttributes.addAttribute("itemId", savedItem.getId());
+        redirectAttributes.addAttribute("status", true);
+        return "redirect:/validation/v2/items/{itemId}";
+    }
+
+    @PostMapping("/add")
+    public String addItemV4(@ModelAttribute Item item, BindingResult bindingResult,
+                            RedirectAttributes redirectAttributes) {
+        log.info("objectName={} ", bindingResult.getObjectName());
+        log.info("target={} ", bindingResult.getTarget());
+
+        if (!StringUtils.hasText(item.getItemName())) {
+            bindingResult.rejectValue("itemName", "required");
+        }
+        if (item.getPrice() == null || item.getPrice() < 1000 || item.getPrice() > 1000000) {
+            bindingResult.rejectValue("price", "range", new Object[] {100, 1000000}, null);
+
+        }
+        if (item.getQuantity() == null || item.getQuantity() >= 10000) {
+            bindingResult.rejectValue("quantity", "max", new Object[]{9999}, null);
+        }
+        //특정 필드 예외가 아닌 전체 예외
+        if (item.getPrice() != null && item.getQuantity() != null) {
+            int resultPrice = item.getPrice() * item.getQuantity();
+            if (resultPrice < 10000) {
+                bindingResult.reject("totalPriceMin", new Object[]{10000, resultPrice}, null);
             }
         }
         if (bindingResult.hasErrors()) {


### PR DESCRIPTION
### 구현 내용
- `BindingResult`의 `rejectValue()`와 `reject()`를 사용하여 검증 오류 처리
- `FieldError`, `ObjectError`를 직접 생성하지 않고 간결한 API 사용으로 대체
- 오류 메시지는 `errors.properties` 파일을 통해 관리
- 메시지 코드는 `range`, `required`, `max`, `totalPriceMin` 등으로 처리하며 자동으로 확장됨

