### PR TITLE
feat: MessageCodesResolver를 통한 오류 코드 자동 생성 적용

### DIFF
--- a/src/test/java/hello/itemservice/validation/MessageCodesResolverTest.java
+++ b/src/test/java/hello/itemservice/validation/MessageCodesResolverTest.java
@@ -1,0 +1,34 @@
+package hello.itemservice.validation;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.validation.DefaultMessageCodesResolver;
+import org.springframework.validation.MessageCodesResolver;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class MessageCodesResolverTest {
+    MessageCodesResolver codesResolver = new DefaultMessageCodesResolver();
+
+    @Test
+    void messageCodesResolverObject() {
+        String[] messageCodes = codesResolver.resolveMessageCodes("required", "item");
+        for (String messageCode : messageCodes) {
+            System.out.println("messageCodes = " + messageCode);
+        }
+        assertThat(messageCodes).containsExactly("required.item", "required");
+    }
+
+    @Test
+    void messageCodesResolverField() {
+        String[] messageCodes = codesResolver.resolveMessageCodes("required", "item", "itemName", String.class);
+        for (String messageCode : messageCodes) {
+            System.out.println("messageCode = " + messageCode);
+        }
+        assertThat(messageCodes).containsExactly(
+                "required.item.itemName",
+                "required.itemName",
+                "required.java.lang.String",
+                "required"
+        );
+    }
+}


### PR DESCRIPTION
### 주요 변경 사항
- rejectValue(), reject() 사용으로 FieldError, ObjectError 직접 생성 코드 제거
- MessageCodesResolver의 메시지 코드 생성 규칙에 따라 오류 메시지 처리 방식 변경
- 필드 및 객체 오류에 대한 코드 자동 생성 
- 타임리프의 th:errors 렌더링 시 코드 순서에 따라 메시지 매칭 
