### PR TITLE
feat: Bean Validation 오브젝트 오류(글로벌 오류) 처리 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.openjdk.nashorn:nashorn-core:15.3'
 }
 
 test {

--- a/src/main/java/hello/itemservice/domain/item/Item.java
+++ b/src/main/java/hello/itemservice/domain/item/Item.java
@@ -2,12 +2,14 @@ package hello.itemservice.domain.item;
 
 import lombok.Data;
 import org.hibernate.validator.constraints.Range;
+import org.hibernate.validator.constraints.ScriptAssert;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Data
+//@ScriptAssert(lang = "javascript", script = "_this.price * _this.quantity >= 10000", message = "총합이 10000원 넘게 입력해주세요.")
 public class Item {
 
     private Long id;

--- a/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV3.java
+++ b/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV3.java
@@ -35,8 +35,15 @@ public class ValidationItemControllerV3 {
         return "validation/v3/addForm";
     }
     @PostMapping("/add")
-    public String addItem(@Validated @ModelAttribute Item item, BindingResult
-            bindingResult, RedirectAttributes redirectAttributes) {
+    public String addItem(@Validated @ModelAttribute Item item, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+        //특정 필드 예외가 아닌 전체 예외
+        if (item.getPrice() != null && item.getQuantity() != null) {
+            int resultPrice = item.getPrice() * item.getQuantity();
+            if (resultPrice < 10000) {
+                bindingResult.reject("totalPriceMin", new Object[]{10000, resultPrice}, null);
+            }
+        }
+
         if (bindingResult.hasErrors()) {
             log.info("errors={}", bindingResult);
             return "validation/v3/addForm";


### PR DESCRIPTION
### 작업 내용
- Bean Validation에서 필드 간 복합 조건(가격 * 수량) 검증 처리
- @ScriptAssert 대신 자바 코드에서 직접 ObjectError 등록
- BindingResult.reject() 사용하여 글로벌 오류 처리 방식 적용

### 기타 참고 사항
- @ScriptAssert는 활용성 측면에서 비권장되어 제거함