### PR TITLE
feat: Bean Validation groups 기능을 이용한 등록/수정 검증 분리

### DIFF
--- a/src/main/java/hello/itemservice/domain/item/Item.java
+++ b/src/main/java/hello/itemservice/domain/item/Item.java
@@ -2,7 +2,6 @@ package hello.itemservice.domain.item;
 
 import lombok.Data;
 import org.hibernate.validator.constraints.Range;
-import org.hibernate.validator.constraints.ScriptAssert;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
@@ -11,18 +10,18 @@ import javax.validation.constraints.NotNull;
 @Data
 public class Item {
 
-    @NotNull
+    @NotNull(groups = UpdateCheck.class)
     private Long id;
 
-    @NotBlank
+    @NotBlank(groups = {SaveCheck.class, UpdateCheck.class})
     private String itemName;
 
-    @NotNull
-    @Range(min = 1000, max = 1000000)
+    @NotNull(groups = {SaveCheck.class, UpdateCheck.class})
+    @Range(min = 1000, max = 1000000, groups = {SaveCheck.class, UpdateCheck.class})
     private Integer price;
 
-    @NotNull
-//    @Max(9999)
+    @NotNull(groups = {SaveCheck.class, UpdateCheck.class})
+    @Max(value = 9999, groups = {SaveCheck.class})
     private Integer quantity;
 
     public Item() {

--- a/src/main/java/hello/itemservice/domain/item/SaveCheck.java
+++ b/src/main/java/hello/itemservice/domain/item/SaveCheck.java
@@ -1,0 +1,4 @@
+package hello.itemservice.domain.item;
+
+public interface SaveCheck {
+}

--- a/src/main/java/hello/itemservice/domain/item/UpdateCheck.java
+++ b/src/main/java/hello/itemservice/domain/item/UpdateCheck.java
@@ -1,0 +1,4 @@
+package hello.itemservice.domain.item;
+
+public interface UpdateCheck {
+}

--- a/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV3.java
+++ b/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV3.java
@@ -1,6 +1,8 @@
 package hello.itemservice.web.validation;
 import hello.itemservice.domain.item.Item;
 import hello.itemservice.domain.item.ItemRepository;
+import hello.itemservice.domain.item.SaveCheck;
+import hello.itemservice.domain.item.UpdateCheck;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -34,8 +36,29 @@ public class ValidationItemControllerV3 {
         model.addAttribute("item", new Item());
         return "validation/v3/addForm";
     }
-    @PostMapping("/add")
+//    @PostMapping("/add")
     public String addItem(@Validated @ModelAttribute Item item, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+        //특정 필드 예외가 아닌 전체 예외
+        if (item.getPrice() != null && item.getQuantity() != null) {
+            int resultPrice = item.getPrice() * item.getQuantity();
+            if (resultPrice < 10000) {
+                bindingResult.reject("totalPriceMin", new Object[]{10000, resultPrice}, null);
+            }
+        }
+
+        if (bindingResult.hasErrors()) {
+            log.info("errors={}", bindingResult);
+            return "validation/v3/addForm";
+        }
+        //성공 로직
+        Item savedItem = itemRepository.save(item);
+        redirectAttributes.addAttribute("itemId", savedItem.getId());
+        redirectAttributes.addAttribute("status", true);
+        return "redirect:/validation/v3/items/{itemId}";
+    }
+
+    @PostMapping("/add")
+    public String addItem2(@Validated(SaveCheck.class) @ModelAttribute Item item, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
         //특정 필드 예외가 아닌 전체 예외
         if (item.getPrice() != null && item.getQuantity() != null) {
             int resultPrice = item.getPrice() * item.getQuantity();
@@ -60,8 +83,26 @@ public class ValidationItemControllerV3 {
         model.addAttribute("item", item);
         return "validation/v3/editForm";
     }
-    @PostMapping("/{itemId}/edit")
+//    @PostMapping("/{itemId}/edit")
     public String edit(@PathVariable Long itemId, @Validated @ModelAttribute Item item, BindingResult bindingResult) {
+
+        if (item.getPrice() != null && item.getQuantity() != null) {
+            int resultPrice = item.getPrice() * item.getQuantity();
+            if (resultPrice < 10000) {
+                bindingResult.reject("totalPriceMin", new Object[]{10000, resultPrice}, null);
+            }
+        }
+
+        if (bindingResult.hasErrors()) {
+            log.info("errors={}", bindingResult);
+            return "validation/v3/editForm";
+        }
+
+        itemRepository.update(itemId, item);
+        return "redirect:/validation/v3/items/{itemId}";
+    }
+    @PostMapping("/{itemId}/edit")
+    public String edit2(@PathVariable Long itemId, @Validated(UpdateCheck.class) @ModelAttribute Item item, BindingResult bindingResult) {
 
         if (item.getPrice() != null && item.getQuantity() != null) {
             int resultPrice = item.getPrice() * item.getQuantity();


### PR DESCRIPTION
### 작업 내용
- 등록과 수정 시 서로 다른 검증 조건을 처리하기 위해 Bean Validation groups 기능 적용
- SaveCheck, UpdateCheck 인터페이스를 통해 상황별로 검증 애노테이션 분리
- Item 클래스에 필드별로 groups 지정
- ValidationItemControllerV3의 addItemV2(), editV2() 메서드에서 각각 그룹 적용

### 주요 변경 사항
- SaveCheck, UpdateCheck 그룹 정의
- Item: 검증 애노테이션에 groups 속성 추가
- 컨트롤러 메서드에서 @Validated(groups) 사용

### 기타 참고 사항
- @Valid는 groups 기능을 지원하지 않아 @Validated 사용
- groups 기능은 구조적으로 유연하지만 복잡도가 증가하므로 실무에서는 폼 객체 분리 방식이 더 선호됨