### PR TITLE
feat: 등록 및 수정용 폼 객체 분리하여 Bean Validation 적용

### DIFF
--- a/src/main/java/hello/itemservice/domain/item/Item.java
+++ b/src/main/java/hello/itemservice/domain/item/Item.java
@@ -10,18 +10,18 @@ import javax.validation.constraints.NotNull;
 @Data
 public class Item {
 
-    @NotNull(groups = UpdateCheck.class)
+//    @NotNull(groups = UpdateCheck.class)
     private Long id;
 
-    @NotBlank(groups = {SaveCheck.class, UpdateCheck.class})
+//    @NotBlank(groups = {SaveCheck.class, UpdateCheck.class})
     private String itemName;
 
-    @NotNull(groups = {SaveCheck.class, UpdateCheck.class})
-    @Range(min = 1000, max = 1000000, groups = {SaveCheck.class, UpdateCheck.class})
+//    @NotNull(groups = {SaveCheck.class, UpdateCheck.class})
+//    @Range(min = 1000, max = 1000000, groups = {SaveCheck.class, UpdateCheck.class})
     private Integer price;
 
-    @NotNull(groups = {SaveCheck.class, UpdateCheck.class})
-    @Max(value = 9999, groups = {SaveCheck.class})
+//    @NotNull(groups = {SaveCheck.class, UpdateCheck.class})
+//    @Max(value = 9999, groups = {SaveCheck.class})
     private Integer quantity;
 
     public Item() {

--- a/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV4.java
+++ b/src/main/java/hello/itemservice/web/validation/ValidationItemControllerV4.java
@@ -2,6 +2,8 @@ package hello.itemservice.web.validation;
 
 import hello.itemservice.domain.item.Item;
 import hello.itemservice.domain.item.ItemRepository;
+import hello.itemservice.web.validation.form.ItemSaveForm;
+import hello.itemservice.web.validation.form.ItemUpdateForm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -19,65 +21,80 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ValidationItemControllerV4 {
     private final ItemRepository itemRepository;
+
     @GetMapping
     public String items(Model model) {
         List<Item> items = itemRepository.findAll();
         model.addAttribute("items", items);
         return "validation/v4/items";
     }
+
     @GetMapping("/{itemId}")
     public String item(@PathVariable long itemId, Model model) {
         Item item = itemRepository.findById(itemId);
         model.addAttribute("item", item);
         return "validation/v4/item";
     }
+
     @GetMapping("/add")
     public String addForm(Model model) {
         model.addAttribute("item", new Item());
         return "validation/v4/addForm";
     }
+
     @PostMapping("/add")
-    public String addItem(@Validated @ModelAttribute Item item, BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+    public String addItem(@Validated @ModelAttribute("item") ItemSaveForm form,
+                          BindingResult bindingResult, RedirectAttributes redirectAttributes) {
         //특정 필드 예외가 아닌 전체 예외
-        if (item.getPrice() != null && item.getQuantity() != null) {
-            int resultPrice = item.getPrice() * item.getQuantity();
+        if (form.getPrice() != null && form.getQuantity() != null) {
+            int resultPrice = form.getPrice() * form.getQuantity();
             if (resultPrice < 10000) {
-                bindingResult.reject("totalPriceMin", new Object[]{10000, resultPrice}, null);
+                bindingResult.reject("totalPriceMin", new Object[]{10000,
+                        resultPrice}, null);
             }
         }
-
         if (bindingResult.hasErrors()) {
             log.info("errors={}", bindingResult);
             return "validation/v4/addForm";
         }
         //성공 로직
+        Item item = new Item();
+        item.setItemName(form.getItemName());
+        item.setPrice(form.getPrice());
+        item.setQuantity(form.getQuantity());
         Item savedItem = itemRepository.save(item);
         redirectAttributes.addAttribute("itemId", savedItem.getId());
         redirectAttributes.addAttribute("status", true);
         return "redirect:/validation/v4/items/{itemId}";
     }
+
     @GetMapping("/{itemId}/edit")
     public String editForm(@PathVariable Long itemId, Model model) {
         Item item = itemRepository.findById(itemId);
         model.addAttribute("item", item);
         return "validation/v4/editForm";
     }
-    @PostMapping("/{itemId}/edit")
-    public String edit(@PathVariable Long itemId, @Validated @ModelAttribute Item item, BindingResult bindingResult) {
 
-        if (item.getPrice() != null && item.getQuantity() != null) {
-            int resultPrice = item.getPrice() * item.getQuantity();
+    @PostMapping("/{itemId}/edit")
+    public String edit(@PathVariable Long itemId, @Validated
+    @ModelAttribute("item") ItemUpdateForm form, BindingResult bindingResult) {
+        //특정 필드 예외가 아닌 전체 예외
+        if (form.getPrice() != null && form.getQuantity() != null) {
+            int resultPrice = form.getPrice() * form.getQuantity();
             if (resultPrice < 10000) {
-                bindingResult.reject("totalPriceMin", new Object[]{10000, resultPrice}, null);
+                bindingResult.reject("totalPriceMin", new Object[]{10000,
+                        resultPrice}, null);
             }
         }
-
         if (bindingResult.hasErrors()) {
             log.info("errors={}", bindingResult);
             return "validation/v4/editForm";
         }
-
-        itemRepository.update(itemId, item);
+        Item itemParam = new Item();
+        itemParam.setItemName(form.getItemName());
+        itemParam.setPrice(form.getPrice());
+        itemParam.setQuantity(form.getQuantity());
+        itemRepository.update(itemId, itemParam);
         return "redirect:/validation/v4/items/{itemId}";
     }
 }

--- a/src/main/java/hello/itemservice/web/validation/form/ItemSaveForm.java
+++ b/src/main/java/hello/itemservice/web/validation/form/ItemSaveForm.java
@@ -1,0 +1,23 @@
+package hello.itemservice.web.validation.form;
+
+import lombok.Data;
+import org.hibernate.validator.constraints.Range;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Data
+public class ItemSaveForm {
+
+    @NotBlank
+    private String itemName;
+
+    @NotNull
+    @Range(min = 1000, max = 1000000)
+    private Integer price;
+
+    @NotNull
+    @Max(value = 9999)
+    private Integer quantity;
+}

--- a/src/main/java/hello/itemservice/web/validation/form/ItemUpdateForm.java
+++ b/src/main/java/hello/itemservice/web/validation/form/ItemUpdateForm.java
@@ -1,0 +1,25 @@
+package hello.itemservice.web.validation.form;
+
+import hello.itemservice.domain.item.UpdateCheck;
+import lombok.Data;
+import org.hibernate.validator.constraints.Range;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Data
+public class ItemUpdateForm {
+
+    @NotNull
+    private Long id;
+
+    @NotBlank
+    private String itemName;
+
+    @NotNull
+    @Range(min = 1000, max = 1000000)
+    private Integer price;
+
+    private Integer quantity;
+}


### PR DESCRIPTION
### 작업 내용
- 등록과 수정 요구사항을 분리하기 위해 Form 객체를 따로 정의
- ItemSaveForm: 등록용, 모든 필드 검증 포함
- ItemUpdateForm: 수정용, id 필수, 수량 무제한 허용
- ValidationItemControllerV4를 통해 폼 객체 바인딩 및 검증 로직 구현
- 검증 후 폼 객체를 Item 객체로 변환하여 저장 및 수정 처리

### 주요 변경 사항
- Item: 검증 애노테이션 제거, 순수 비즈니스 모델로 원복
- ItemSaveForm, ItemUpdateForm: 등록/수정 상황에 맞는 검증 조건 정의
- ValidationItemControllerV4: add/edit 처리 방식 변경

### 기타 참고 사항
- @ModelAttribute("item") 명시하여 뷰 템플릿과의 바인딩 명확화
- 폼 객체 도입으로 groups 기능 없이도 명확한 검증 구조 구성
