### PR TITLE
feat: @RequestBody 기반 Bean Validation 적용 API 컨트롤러 추가

### DIFF
--- a/src/main/java/hello/itemservice/web/validation/ValidationItemApiController.java
+++ b/src/main/java/hello/itemservice/web/validation/ValidationItemApiController.java
@@ -1,0 +1,30 @@
+package hello.itemservice.web.validation;
+
+import hello.itemservice.web.validation.form.ItemSaveForm;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/validation/api/items")
+public class ValidationItemApiController {
+
+    @PostMapping("/add")
+    public Object addItem(@RequestBody @Validated ItemSaveForm form, BindingResult bindingResult){
+        log.info("API 컨트롤러 호출");
+
+        if (bindingResult.hasErrors()) {
+            log.info("검증 오류 발생 errors={}", bindingResult );
+            return bindingResult.getAllErrors();
+        }
+
+        log.info("성공 로직 실행");
+        return form;
+    }
+
+}


### PR DESCRIPTION
### 작업 내용
- HTTP 요청 본문(@RequestBody)에 대한 Bean Validation 적용
- ValidationItemApiController에서 ItemSaveForm을 JSON으로 받아 검증 수행
- 변환 실패와 검증 실패를 구분하여 처리

### 주요 변경 사항
- ValidationItemApiController: @RequestBody + @Validated 처리 및 BindingResult 사용
- Postman 테스트 기준 성공 요청, JSON 파싱 실패 요청, 검증 실패 요청 처리 시나리오 구현

### 기타 참고 사항
- JSON 변환에 실패하면 컨트롤러 호출 전 HttpMessageNotReadableException 발생
- 검증 오류 발생 시 bindingResult.getAllErrors()로 오류 정보 반환 (예시용)
- 실무에서는 검증 오류 응답 객체를 별도로 정의하는 것이 권장됨
